### PR TITLE
Manually provide a .npmrc file for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,11 +10,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@weaveworksoss'
       - run: |
           cd plugins/backstage-plugin-flux
           yarn install --frozen-lockfile
+
+          # copy over the example npmrc file and publish
+          cp .npmrc.example .npmrc
           ./publish.sh
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- the setup-node github action seems to copying the .npmrc to the project root which might be causing issues.