### PR TITLE
Fix GitRepositories test data.

### DIFF
--- a/plugins/backstage-plugin-flux/dev/index.tsx
+++ b/plugins/backstage-plugin-flux/dev/index.tsx
@@ -23,7 +23,11 @@ import {
   FluxEntityHelmReleasesCard,
   FluxEntityGitRepositoriesCard,
 } from '../src/plugin';
-import { newTestHelmRelease, newTestOCIRepository } from './helpers';
+import {
+  newTestHelmRelease,
+  newTestOCIRepository,
+  newTestGitRepository
+} from './helpers';
 import { FluxEntityOCIRepositoriesCard } from '../src/components/FluxEntityOCIRepositoriesCard';
 import { ReconcileRequestAnnotation } from '../src/hooks';
 
@@ -41,60 +45,6 @@ const fakeEntity: Entity = {
     lifecycle: 'production',
     type: 'service',
     owner: 'user:guest',
-  },
-};
-
-const fakeGitRepository = {
-  apiVersion: 'source.toolkit.fluxcd.io/v1',
-  kind: 'GitRepository',
-  metadata: {
-    creationTimestamp: '2023-06-22T17:58:23Z',
-    finalizers: ['finalizers.fluxcd.io'],
-    generation: 1,
-    name: 'podinfo',
-    namespace: 'default',
-    resourceVersion: '132764',
-    uid: '068ec137-b2a0-4b35-90ea-4e9a8a2fe5f6',
-  },
-  spec: {
-    interval: '1m',
-    ref: {
-      branch: 'master',
-    },
-    timeout: '60s',
-    url: 'https://github.com/stefanprodan/podinfo',
-  },
-  status: {
-    artifact: {
-      digest:
-        'sha256:f1e2d4a8244772c47d5e10b38768acec57dc404d6409464c15d2eb8c84b28b51',
-      lastUpdateTime: '2023-06-22T17:58:24Z',
-      path: 'gitrepository/default/podinfo/e06a5517daf5ac8c5ba74a97135499e40624885a.tar.gz',
-      revision: 'master@sha1:e06a5517daf5ac8c5ba74a97135499e40624885a',
-      size: 80053,
-      url: 'http://source-controller.flux-system.svc.cluster.local./gitrepository/default/podinfo/e06a5517daf5ac8c5ba74a97135499e40624885a.tar.gz',
-    },
-    conditions: [
-      {
-        lastTransitionTime: '2023-06-22T17:58:24Z',
-        message:
-          "stored artifact for revision 'master@sha1:e06a5517daf5ac8c5ba74a97135499e40624885a'",
-        observedGeneration: 1,
-        reason: 'Succeeded',
-        status: 'True',
-        type: 'Ready',
-      },
-      {
-        lastTransitionTime: '2023-06-22T17:58:24Z',
-        message:
-          "stored artifact for revision 'master@sha1:e06a5517daf5ac8c5ba74a97135499e40624885a'",
-        observedGeneration: 1,
-        reason: 'Succeeded',
-        status: 'True',
-        type: 'ArtifactInStorage',
-      },
-    ],
-    observedGeneration: 1,
   },
 };
 
@@ -271,7 +221,27 @@ createDevApp()
               gitops: { baseUrl: 'https://example.com/wego' },
             }),
           ],
-          [kubernetesApiRef, new StubKubernetesClient([fakeGitRepository])],
+          [kubernetesApiRef, new StubKubernetesClient([
+            newTestGitRepository(
+              'podinfo',
+              'https://github.com/stefanprodan/podinfo',
+              { verify: true, verified: true },
+            ),
+            newTestGitRepository(
+              'weave-gitops',
+              'https://github.com/weaveworks/weave-gitops',
+            ),
+            newTestGitRepository(
+              'weaveworks-backstage',
+              'https://github.com/weaveworks/weaveworks-backstage',
+              { verify: true, verified: false}
+            ),
+            newTestGitRepository(
+              'weave-gitops-enterprise',
+              'https://github.com/weaveworks/weave-gitops-enterprise',
+            ),                        
+          ])
+          ],
           [kubernetesAuthProvidersApiRef, new StubKubernetesAuthProvidersApi()],
         ]}
       >
@@ -282,7 +252,7 @@ createDevApp()
     ),
   })
   .addPage({
-    title: 'Oci Repositories',
+    title: 'OCI Repositories',
     path: '/oci-repositories',
     element: (
       <TestApiProvider
@@ -299,8 +269,7 @@ createDevApp()
               newTestOCIRepository(
                 'podinfo',
                 'oci://ghcr.io/stefanprodan/manifests/podinfo',
-                true,
-                true,
+                { verify: true, verified: true },
               ),
               newTestOCIRepository(
                 'redis',
@@ -309,22 +278,22 @@ createDevApp()
               newTestOCIRepository(
                 'postgresql',
                 'oci://registry-1.docker.io/bitnamicharts/postgresql',
-                true,
-                false,
+                { verify: true, verified: false },
               ),
               newTestOCIRepository(
                 'apache',
                 'oci://registry-1.docker.io/bitnamicharts/apache',
+                {ready: false}
               ),
               newTestOCIRepository(
                 'supabase',
                 'oci://registry-1.docker.io/bitnamicharts/supabase',
+                { verify: true, pending: true },
               ),
               newTestOCIRepository(
                 'mariadb',
                 'oci://registry-1.docker.io/bitnamicharts/mariadb',
-                true,
-                false,
+                { verify: true, verified: false },
               ),
             ]),
           ],

--- a/plugins/backstage-plugin-flux/src/__fixtures__/git_repository.json
+++ b/plugins/backstage-plugin-flux/src/__fixtures__/git_repository.json
@@ -1,0 +1,55 @@
+{
+    "apiVersion": "source.toolkit.fluxcd.io/v1",
+    "kind": "GitRepository",
+    "metadata": {
+        "creationTimestamp": "2023-06-30T08:47:28Z",
+        "finalizers": [
+            "finalizers.fluxcd.io"
+        ],
+        "generation": 1,
+        "labels": {
+            "backstage.io/kubernetes-id": "catalogue-service"
+        },
+        "name": "podinfo",
+        "namespace": "backstage",
+        "resourceVersion": "952453",
+        "uid": "c1659d91-b493-4063-ac38-12033a27f2d7"
+    },
+    "spec": {
+        "interval": "10m",
+        "ref": {
+            "branch": "master"
+        },
+        "timeout": "60s",
+        "url": "https://github.com/stefanprodan/podinfo"
+    },
+    "status": {
+        "artifact": {
+            "digest": "sha256:c894e5fad8e3a51ba4be72ada4beef3ee7be99f66770fd6f16488982bd226de8",
+            "lastUpdateTime": "2023-06-30T08:47:29Z",
+            "path": "gitrepository/backstage/podinfo/dd3869b1a177432b60ea1e3ba99c10fc9db850fa.tar.gz",
+            "revision": "master@sha1:dd3869b1a177432b60ea1e3ba99c10fc9db850fa",
+            "size": 80066,
+            "url": "http://source-controller.flux-system.svc.cluster.local./gitrepository/backstage/podinfo/dd3869b1a177432b60ea1e3ba99c10fc9db850fa.tar.gz"
+        },
+        "conditions": [
+            {
+                "lastTransitionTime": "2023-06-30T08:47:29Z",
+                "message": "stored artifact for revision 'master@sha1:dd3869b1a177432b60ea1e3ba99c10fc9db850fa'",
+                "observedGeneration": 1,
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastTransitionTime": "2023-06-30T08:47:29Z",
+                "message": "stored artifact for revision 'master@sha1:dd3869b1a177432b60ea1e3ba99c10fc9db850fa'",
+                "observedGeneration": 1,
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "ArtifactInStorage"
+            }
+        ],
+        "observedGeneration": 1
+    }
+}

--- a/plugins/backstage-plugin-flux/src/__fixtures__/unverified_git_repository.json
+++ b/plugins/backstage-plugin-flux/src/__fixtures__/unverified_git_repository.json
@@ -1,0 +1,61 @@
+{
+    "apiVersion": "source.toolkit.fluxcd.io/v1",
+    "kind": "GitRepository",
+    "metadata": {
+        "creationTimestamp": "2023-06-30T08:46:33Z",
+        "finalizers": [
+            "finalizers.fluxcd.io"
+        ],
+        "generation": 1,
+        "labels": {
+            "backstage.io/kubernetes-id": "catalogue-service"
+        },
+        "name": "podinfo",
+        "namespace": "backstage",
+        "resourceVersion": "952298",
+        "uid": "8ed938dc-8bcd-481c-ae53-39739cfc1737"
+    },
+    "spec": {
+        "interval": "10m",
+        "ref": {
+            "branch": "master"
+        },
+        "timeout": "60s",
+        "url": "https://github.com/stefanprodan/podinfo",
+        "verify": {
+            "mode": "head",
+            "secretRef": {
+                "name": "pgp-public-keys"
+            }
+        }
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2023-06-30T08:46:59Z",
+                "message": "building artifact",
+                "observedGeneration": 1,
+                "reason": "Progressing",
+                "status": "True",
+                "type": "Reconciling"
+            },
+            {
+                "lastTransitionTime": "2023-06-30T08:46:59Z",
+                "message": "building artifact",
+                "observedGeneration": 1,
+                "reason": "Progressing",
+                "status": "Unknown",
+                "type": "Ready"
+            },
+            {
+                "lastTransitionTime": "2023-06-30T08:46:35Z",
+                "message": "signature verification of commit 'dd3869b1a177432b60ea1e3ba99c10fc9db850fa' failed: unable to verify commit with any of the given key rings",
+                "observedGeneration": 1,
+                "reason": "InvalidCommitSignature",
+                "status": "False",
+                "type": "SourceVerified"
+            }
+        ],
+        "observedGeneration": -1
+    }
+}

--- a/plugins/backstage-plugin-flux/src/__fixtures__/verified_git_repository.json
+++ b/plugins/backstage-plugin-flux/src/__fixtures__/verified_git_repository.json
@@ -1,0 +1,72 @@
+{
+    "apiVersion": "source.toolkit.fluxcd.io/v1",
+    "kind": "GitRepository",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"source.toolkit.fluxcd.io/v1\",\"kind\":\"GitRepository\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"catalogue-service\"},\"name\":\"podinfo\",\"namespace\":\"backstage\"},\"spec\":{\"interval\":\"10m\",\"ref\":{\"branch\":\"master\"},\"url\":\"https://github.com/stefanprodan/podinfo\",\"verify\":{\"mode\":\"head\",\"secretRef\":{\"name\":\"pgp-public-keys\"}}}}\n"
+        },
+        "creationTimestamp": "2023-06-29T13:50:21Z",
+        "finalizers": [
+            "finalizers.fluxcd.io"
+        ],
+        "generation": 1,
+        "labels": {
+            "backstage.io/kubernetes-id": "catalogue-service"
+        },
+        "name": "podinfo",
+        "namespace": "backstage",
+        "resourceVersion": "690736",
+        "uid": "45314994-3b63-4dad-87b3-61341b617fea"
+    },
+    "spec": {
+        "interval": "10m",
+        "ref": {
+            "branch": "master"
+        },
+        "timeout": "60s",
+        "url": "https://github.com/stefanprodan/podinfo",
+        "verify": {
+            "mode": "head",
+            "secretRef": {
+                "name": "pgp-public-keys"
+            }
+        }
+    },
+    "status": {
+        "artifact": {
+            "digest": "sha256:c894e5fad8e3a51ba4be72ada4beef3ee7be99f66770fd6f16488982bd226de8",
+            "lastUpdateTime": "2023-06-29T13:50:23Z",
+            "path": "gitrepository/backstage/podinfo/dd3869b1a177432b60ea1e3ba99c10fc9db850fa.tar.gz",
+            "revision": "master@sha1:dd3869b1a177432b60ea1e3ba99c10fc9db850fa",
+            "size": 80066,
+            "url": "http://source-controller.flux-system.svc.cluster.local./gitrepository/backstage/podinfo/dd3869b1a177432b60ea1e3ba99c10fc9db850fa.tar.gz"
+        },
+        "conditions": [
+            {
+                "lastTransitionTime": "2023-06-29T13:50:23Z",
+                "message": "stored artifact for revision 'master@sha1:dd3869b1a177432b60ea1e3ba99c10fc9db850fa'",
+                "observedGeneration": 1,
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastTransitionTime": "2023-06-29T13:50:23Z",
+                "message": "stored artifact for revision 'master@sha1:dd3869b1a177432b60ea1e3ba99c10fc9db850fa'",
+                "observedGeneration": 1,
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "ArtifactInStorage"
+            },
+            {
+                "lastTransitionTime": "2023-06-29T13:50:23Z",
+                "message": "verified signature of commit 'dd3869b1a177432b60ea1e3ba99c10fc9db850fa'",
+                "observedGeneration": 1,
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "SourceVerified"
+            }
+        ],
+        "observedGeneration": 1
+    }
+}

--- a/plugins/backstage-plugin-flux/src/components/FluxEntityGitRepositoriesCard/FluxGitRepositoriesTable.tsx
+++ b/plugins/backstage-plugin-flux/src/components/FluxEntityGitRepositoriesCard/FluxGitRepositoriesTable.tsx
@@ -19,7 +19,7 @@ export const defaultColumns: TableColumn<GitRepository>[] = [
   nameAndClusterNameColumn(),
   verifiedColumn(),
   urlColumn(),
-  tagColumn(),
+  tagColumn('Ref'),
   statusColumn(),
   updatedColumn(),
   syncColumn(),
@@ -68,7 +68,7 @@ export const FluxGitRepositoriesTable = ({
     return (
       <Table
         columns={columns}
-        options={{ padding: 'dense', paging: true, search: false, pageSize: 5 }}
+        options={{ padding: 'dense', paging: true, search: true, pageSize: 5 }}
         title="Git Repositories"
         data={data}
         isLoading={isLoading}

--- a/plugins/backstage-plugin-flux/src/components/FluxEntityOCIRepositoriesCard/FluxOCIRepositoriesTable.tsx
+++ b/plugins/backstage-plugin-flux/src/components/FluxEntityOCIRepositoriesCard/FluxOCIRepositoriesTable.tsx
@@ -19,7 +19,7 @@ export const defaultColumns: TableColumn<OCIRepository>[] = [
   nameAndClusterNameColumn(),
   verifiedColumn(),
   urlColumn(),
-  tagColumn(),
+  tagColumn('Tag'),
   statusColumn(),
   updatedColumn(),
   syncColumn(),

--- a/plugins/backstage-plugin-flux/src/components/helpers.tsx
+++ b/plugins/backstage-plugin-flux/src/components/helpers.tsx
@@ -158,9 +158,9 @@ export const urlColumn = () => {
   };
 };
 
-export const tagColumn = () => {
+export const tagColumn = (title: string) => {
   return {
-    title: 'URL',
+    title: title,
     render: (resource: GitRepository | OCIRepository) => {
       return <span>{resource.artifact?.revision.split('@')[0]}</span>;
     },


### PR DESCRIPTION
This adds some additional test data for GitRepositories.

I fixed the column titling (it was URL x 2) but this highlights that we should probably change this a bit to reflect the desired branch for GitRepositories.

Also, OCI Repository `supabase` should be yellow (pending) I think?