### PR TITLE
Fix URL generation bug.

### DIFF
--- a/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.test.tsx
+++ b/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.test.tsx
@@ -80,6 +80,22 @@ describe('useWeaveFluxDeepLink', () => {
     });
   });
 
+  describe('when the url ends with a trailing slash', () => {
+    it('drops it from the generated URL', async () => {
+      gitOpsUrl = 'https://example.com/';
+
+      const { result } = renderHook(
+        () => useWeaveFluxDeepLink(testHelmRelease),
+        {
+          wrapper,
+        },
+      );
+      expect(result.current).toBe(
+        'https://example.com/helm_release/details?clusterName=&name=normal&namespace=default',
+      );
+    });
+  });
+
   describe('when configured without a gitops url', () => {
     it('returns undefined', async () => {
       const { result } = renderHook(

--- a/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.ts
+++ b/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.ts
@@ -12,11 +12,12 @@ const typedUrl = (baseUrl: string, a: FluxObject, type: string): string => {
     name: a.name,
     namespace: a.namespace,
   };
+
   const queryString = Object.entries(queryStringData)
     .map(([key, value]) => `${key}=${value}`)
     .join('&');
 
-  return `${baseUrl}/${type}/details?${queryString}`;
+  return `${baseUrl.replace(/\/$/, "")}/${type}/details?${queryString}`;
 };
 
 export const useWeaveFluxDeepLink = (


### PR DESCRIPTION
This ensures that gitops URLs that end with a trailing / have this removed before concatenating for the Weave GitOps URL.