### PR TITLE
More publishing fixes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # get all the tags
+          # get all the tags from git so we can run
+          # $(git describe --tags) and get something useful
+          # e.g. v0.6.0 or v0.6.0-1-gf0a2b3c
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:

--- a/plugins/backstage-plugin-flux/publish.sh
+++ b/plugins/backstage-plugin-flux/publish.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 
+# bail on error
 set -e
+# print each command
 set -x
 
+# e.g.
+# v0.6.0 for a tag
+# v0.6.0-1-gf0a2b3c for some non-tagged commit
 NEW_VERSION=$(git describe --always --tags --match "v*")
+
+# npm requires that leading v to be stripped to be "valid semver"
+# e.g. 0.6.0
 STRIPPED_NEW_VERSION=$(echo $NEW_VERSION | sed -e 's/^v//')
 
 yarn clean
 yarn tsc
 yarn build
+
 # don't git commit or push
 yarn publish --new-version $STRIPPED_NEW_VERSION --no-git-tag-version


### PR DESCRIPTION
Worked this time:

https://www.npmjs.com/package/@weaveworksoss/backstage-plugin-flux?activeTab=versions

Now have some junk releases on npm which doesn't seem to mind, we could consider publishing from branches to make it easier to test things.