### PR TITLE
Allow per-cluster configuration of the baseUrl.

### DIFF
--- a/plugins/backstage-plugin-flux/README.md
+++ b/plugins/backstage-plugin-flux/README.md
@@ -154,3 +154,14 @@ gitops:
   #
   baseUrl: https://wego.example.com
 ```
+
+Alternatively, if you have multiple installations, you can provide a per-Cluster
+configuration URL.
+
+```yaml
+gitops:
+  cluster1:
+    baseUrl: https://cluster1.example.com
+  cluster2:
+    baseUrl: https://cluser2.example.com
+```

--- a/plugins/backstage-plugin-flux/config.d.ts
+++ b/plugins/backstage-plugin-flux/config.d.ts
@@ -1,6 +1,21 @@
+/**
+ * Represents the configuration for the Plugin.
+ */
 export interface Config {
-  gitops?: {
-    /** @visibility frontend */
-    baseUrl?: string;
-  };
+  gitops?:
+  | {
+    /**
+     * (Required) The baseUrl of a Weave GitOps server to link to.
+     */
+    baseUrl: string;
+  }
+  | Record<
+    string,
+    {
+      /**
+       * (Required) The baseUrl of a Weave GitOps server to link to.
+       */
+      baseUrl: string;
+    }
+  >;
 }

--- a/plugins/backstage-plugin-flux/package.json
+++ b/plugins/backstage-plugin-flux/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "^1.3.0",
+    "@backstage/config": "^1.0.8",
     "@backstage/core-components": "^0.13.1",
     "@backstage/core-plugin-api": "^1.5.1",
     "@backstage/plugin-catalog-react": "^1.6.0",

--- a/plugins/backstage-plugin-flux/src/hooks/WeaveGitOpsConfig.test.ts
+++ b/plugins/backstage-plugin-flux/src/hooks/WeaveGitOpsConfig.test.ts
@@ -1,0 +1,59 @@
+import { ConfigReader } from '@backstage/config';
+
+import { DEFAULT_CLUSTER_ID, readGitOpsClusterConfigs } from './WeaveGitOpsConfig';
+
+describe('readGitOpsClusterConfigs', () => {
+  describe('when there is no configuration provided', () => {
+    it('reads no configuration', () => {
+      const config = new ConfigReader({});
+      const clusterConfigs = readGitOpsClusterConfigs(config);
+
+      expect(clusterConfigs).toHaveLength(0);
+    });
+  });
+
+  describe('when a single configuration is provided', () => {
+    it('reads a single cluster configuration', () => {
+      const config = new ConfigReader({
+        gitops: { baseUrl: 'https://wego.example.com' },
+      });
+
+      const clusterConfigs = readGitOpsClusterConfigs(config);
+
+      expect(clusterConfigs).toEqual([
+        {
+          baseUrl: 'https://wego.example.com',
+          name: DEFAULT_CLUSTER_ID,
+        }
+      ]);
+    });
+  });
+
+  describe('when multiple configurations are provided', () => {
+    it('reads multiple cluster configurations', () => {
+      const config = new ConfigReader({
+        gitops: {
+          'prod-cluster': {
+            baseUrl: 'https://wego1.example.com',
+          },
+          'dev-cluster': {
+            baseUrl: 'https://wego2.example.com',
+          }
+        },
+      });
+
+      const clusterConfigs = readGitOpsClusterConfigs(config);
+
+      expect(clusterConfigs).toEqual([
+        {
+          baseUrl: 'https://wego1.example.com',
+          name: 'prod-cluster',
+        },
+        {
+          baseUrl: 'https://wego2.example.com',
+          name: 'dev-cluster',
+        },
+      ]);
+    });
+  });
+});

--- a/plugins/backstage-plugin-flux/src/hooks/WeaveGitOpsConfig.ts
+++ b/plugins/backstage-plugin-flux/src/hooks/WeaveGitOpsConfig.ts
@@ -1,0 +1,39 @@
+import { Config } from '@backstage/config';
+
+export const DEFAULT_CLUSTER_ID = 'Default';
+
+export type WeaveGitopsClusterConfig = {
+  name: string;
+  baseUrl: string;
+};
+
+function readClusterConfig(
+  name: string,
+  config: Config,
+): WeaveGitopsClusterConfig {
+  const baseUrl = config.getString('baseUrl');
+
+  return {
+    name,
+    baseUrl
+  };
+}
+
+export function readGitOpsClusterConfigs(
+  config: Config,
+): WeaveGitopsClusterConfig[] {
+  const gitopsConfig = config.getOptionalConfig('gitops');
+  if (!gitopsConfig) {
+    return [];
+  }
+
+  if (gitopsConfig.has('baseUrl')) {
+    return [readClusterConfig(DEFAULT_CLUSTER_ID, gitopsConfig)];
+  }
+
+  return gitopsConfig.keys().map(name => {
+    const clusterConfig = gitopsConfig.getConfig(name);
+
+    return readClusterConfig(name, clusterConfig);
+  });
+};

--- a/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.test.tsx
+++ b/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.test.tsx
@@ -1,6 +1,7 @@
 import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
 import { renderHook } from '@testing-library/react-hooks';
+import { ConfigReader } from '@backstage/config';
 import React, { PropsWithChildren } from 'react';
 import { useWeaveFluxDeepLink } from './useWeaveFluxDeepLink';
 import { GitRepository, HelmRelease, OCIRepository } from '../objects';
@@ -8,23 +9,30 @@ import { GitRepository, HelmRelease, OCIRepository } from '../objects';
 const testHelmRelease = new HelmRelease({
   payload:
     '{"apiVersion":"helm.toolkit.fluxcd.io/v2beta1","kind":"HelmRelease","metadata":{"annotations":{"metadata.weave.works/test":"value"},"creationTimestamp":"2023-05-25T14:14:46Z","finalizers":["finalizers.fluxcd.io"],"generation":5,"name":"normal","namespace":"default","resourceVersion":"1","uid":"82231842-2224-4f22-8576-5babf08d746d"}}',
+  clusterName: 'Default',
 });
 const testGitRepository = new GitRepository({
   payload:
     '{"apiVersion":"source.toolkit.fluxcd.io/v1","kind":"GitRepository","metadata":{"creationTimestamp":"2023-06-22T17:58:23Z","finalizers":["finalizers.fluxcd.io"],"generation":1,"name":"podinfo","namespace":"default","resourceVersion":"137468","uid":"068ec137-b2a0-4b35-90ea-4e9a8a2fe5f6"},"spec":{"interval":"1m","ref":{"branch":"master"},"timeout":"60s","url":"https://github.com/stefanprodan/podinfo"},"status":{"artifact":{"digest":"sha256:f1e2d4a8244772c47d5e10b38768acec57dc404d6409464c15d2eb8c84b28b51","lastUpdateTime":"2023-06-22T17:58:24Z","path":"gitrepository/default/podinfo/e06a5517daf5ac8c5ba74a97135499e40624885a.tar.gz","revision":"master@sha1:e06a5517daf5ac8c5ba74a97135499e40624885a","size":80053,"url":"http://source-controller.flux-system.svc.cluster.local./gitrepository/default/podinfo/e06a5517daf5ac8c5ba74a97135499e40624885a.tar.gz"},"conditions":[{"lastTransitionTime":"2023-06-23T06:58:24Z","message":"stored artifact for revision \'master@sha1:e06a5517daf5ac8c5ba74a97135499e40624885a\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"Ready"},{"lastTransitionTime":"2023-06-22T17:58:24Z","message":"stored artifact for revision \'master@sha1:e06a5517daf5ac8c5ba74a97135499e40624885a\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"ArtifactInStorage"}],"observedGeneration":1}}',
+  clusterName: 'Default',
 });
 const testOCIRepository = new OCIRepository({
   payload: `{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","kind":"OCIRepository","metadata":{"creationTimestamp":"2023-06-23T07:50:47Z","finalizers":["finalizers.fluxcd.io"],"generation":1,"name":"podinfo","namespace":"default","resourceVersion":"143955","uid":"1ec54278-ed2d-4f31-9bb0-39dc7163730e"},"spec":{"interval":"5m","provider":"generic","timeout":"60s","url":"oci://ghcr.io/stefanprodan/manifests/podinfo","verify":{"provider":"cosign"}},"status":{"artifact":{"digest":"sha256:62df151eb3714d9dfa943c7d88192d72466bffa268b25595f85530b793f77524","lastUpdateTime":"2023-06-23T07:50:53Z","metadata":{"org.opencontainers.image.created":"2023-05-03T14:30:58Z","org.opencontainers.image.revision":"6.3.6/073f1ec5aff930bd3411d33534e91cbe23302324","org.opencontainers.image.source":"https://github.com/stefanprodan/podinfo"},"path":"ocirepository/default/podinfo/sha256:2982c337af6ba98c0e9224a5d7149a19baa9cbedea09b16ae44253682050b6a4.tar.gz","revision":"latest@sha256:2982c337af6ba98c0e9224a5d7149a19baa9cbedea09b16ae44253682050b6a4","size":1071,"url":"http://source-controller.flux-system.svc.cluster.local./ocirepository/default/podinfo/sha256:2982c337af6ba98c0e9224a5d7149a19baa9cbedea09b16ae44253682050b6a4.tar.gz"},"conditions":[{"lastTransitionTime":"2023-06-23T07:50:53Z","message":"stored artifact for digest 'latest@sha256:2982c337af6ba98c0e9224a5d7149a19baa9cbedea09b16ae44253682050b6a4'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"Ready"},{"lastTransitionTime":"2023-06-23T07:50:53Z","message":"stored artifact for digest 'latest@sha256:2982c337af6ba98c0e9224a5d7149a19baa9cbedea09b16ae44253682050b6a4'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"ArtifactInStorage"}],"observedGeneration":1,"url":"http://source-controller.flux-system.svc.cluster.local./ocirepository/default/podinfo/latest.tar.gz"}}`,
+  clusterName: 'Default',
 });
 
-let gitOpsUrl: string | undefined;
-const mockConfigApi = {
-  getOptionalString: jest.fn(() => gitOpsUrl),
-} as Partial<ConfigApi>;
+// Is there a nicer way of doing this?!
+let config: any
+const makeMockConfigApi = (): ConfigApi => {
+  if (!config) {
+    return new ConfigReader({});
+  }
+  return new ConfigReader(config)
+};
 
 const wrapper = ({ children }: PropsWithChildren<{}>) => {
   return (
-    <TestApiProvider apis={[[configApiRef, mockConfigApi]]}>
+    <TestApiProvider apis={[[configApiRef, makeMockConfigApi()]]}>
       {children}
     </TestApiProvider>
   );
@@ -33,12 +41,16 @@ const wrapper = ({ children }: PropsWithChildren<{}>) => {
 describe('useWeaveFluxDeepLink', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    gitOpsUrl = undefined;
+    config = undefined;
   });
 
   describe('when configured with a gitops url', () => {
     it('calculates a url for HelmReleases', async () => {
-      gitOpsUrl = 'https://example.com';
+      config = {
+        gitops: {
+          baseUrl: 'https://example.com'
+        }
+      };
 
       const { result } = renderHook(
         () => useWeaveFluxDeepLink(testHelmRelease),
@@ -47,13 +59,16 @@ describe('useWeaveFluxDeepLink', () => {
         },
       );
       expect(result.current).toBe(
-        'https://example.com/helm_release/details?clusterName=&name=normal&namespace=default',
+        'https://example.com/helm_release/details?clusterName=Default&name=normal&namespace=default',
       );
     });
 
     it('calculates a url for GitRepositories', async () => {
-      gitOpsUrl = 'https://example.com';
-
+      config = {
+        gitops: {
+          baseUrl: 'https://example.com'
+        }
+      };
       const { result } = renderHook(
         () => useWeaveFluxDeepLink(testGitRepository),
         {
@@ -61,13 +76,16 @@ describe('useWeaveFluxDeepLink', () => {
         },
       );
       expect(result.current).toBe(
-        'https://example.com/git_repo/details?clusterName=&name=podinfo&namespace=default',
+        'https://example.com/git_repo/details?clusterName=Default&name=podinfo&namespace=default',
       );
     });
 
     it('calculates a url for OCIRepositories', async () => {
-      gitOpsUrl = 'https://example.com';
-
+      config = {
+        gitops: {
+          baseUrl: 'https://example.com'
+        }
+      };
       const { result } = renderHook(
         () => useWeaveFluxDeepLink(testOCIRepository),
         {
@@ -75,15 +93,18 @@ describe('useWeaveFluxDeepLink', () => {
         },
       );
       expect(result.current).toBe(
-        'https://example.com/oci/details?clusterName=&name=podinfo&namespace=default',
+        'https://example.com/oci/details?clusterName=Default&name=podinfo&namespace=default',
       );
     });
   });
 
   describe('when the url ends with a trailing slash', () => {
     it('drops it from the generated URL', async () => {
-      gitOpsUrl = 'https://example.com/';
-
+      config = {
+        gitops: {
+          baseUrl: 'https://example.com/'
+        }
+      };
       const { result } = renderHook(
         () => useWeaveFluxDeepLink(testHelmRelease),
         {
@@ -91,7 +112,37 @@ describe('useWeaveFluxDeepLink', () => {
         },
       );
       expect(result.current).toBe(
-        'https://example.com/helm_release/details?clusterName=&name=normal&namespace=default',
+        'https://example.com/helm_release/details?clusterName=Default&name=normal&namespace=default',
+      );
+    });
+  });
+
+  describe('when resource is from a different cluster', () => {
+    it('generates it from the generated URL', async () => {
+      const clusterHelmRelease = new HelmRelease({
+        payload:
+          '{"apiVersion":"helm.toolkit.fluxcd.io/v2beta1","kind":"HelmRelease","metadata":{"annotations":{"metadata.weave.works/test":"value"},"creationTimestamp":"2023-05-25T14:14:46Z","finalizers":["finalizers.fluxcd.io"],"generation":5,"name":"normal","namespace":"default","resourceVersion":"1","uid":"82231842-2224-4f22-8576-5babf08d746d"}}',
+        clusterName: 'other-cluster'
+      });
+      config = {
+        gitops: {
+          'Default': {
+            baseUrl: 'https://example.com',
+          },
+          'other-cluster': {
+            baseUrl: 'https://other.example.com',
+          },
+        },
+      };
+      const { result } = renderHook(
+        () => useWeaveFluxDeepLink(clusterHelmRelease),
+        {
+          wrapper,
+        },
+      );
+
+      expect(result.current).toBe(
+        'https://other.example.com/helm_release/details?clusterName=other-cluster&name=normal&namespace=default',
       );
     });
   });

--- a/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.ts
+++ b/plugins/backstage-plugin-flux/src/hooks/useWeaveFluxDeepLink.ts
@@ -1,4 +1,5 @@
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { Config } from '@backstage/config';
 import {
   FluxObject,
   GitRepository,
@@ -7,6 +8,7 @@ import {
   HelmRepository,
   OCIRepository,
 } from '../objects';
+import { WeaveGitopsClusterConfig, readGitOpsClusterConfigs } from './WeaveGitOpsConfig';
 
 const typedUrl = (baseUrl: string, a: FluxObject, type: string): string => {
   const queryStringData = {
@@ -22,11 +24,26 @@ const typedUrl = (baseUrl: string, a: FluxObject, type: string): string => {
   return `${baseUrl.replace(/\/$/, '')}/${type}/details?${queryString}`;
 };
 
+const baseUrlForCluster = (config: Config, resource: FluxObject): string | undefined => {
+  const clusterConfigs = readGitOpsClusterConfigs(config);
+  if (clusterConfigs.length === 0) {
+    return undefined;
+  }
+
+  if (clusterConfigs.length === 1) {
+    return clusterConfigs[0].baseUrl;
+  }
+
+  return clusterConfigs.find(
+    (clusterConf: WeaveGitopsClusterConfig) =>
+      clusterConf.name === resource.clusterName)?.baseUrl;
+}
+
 export const useWeaveFluxDeepLink = (
   resource: FluxObject,
 ): string | undefined => {
   const config = useApi(configApiRef);
-  const baseUrl = config.getOptionalString('gitops.baseUrl');
+  const baseUrl = baseUrlForCluster(config, resource);
 
   if (!baseUrl) {
     return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,6 +2616,14 @@
     "@backstage/types" "^1.0.2"
     lodash "^4.17.21"
 
+"@backstage/config@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.0.8.tgz#283a4900c7aae216bd4e3dce4389ce060f989884"
+  integrity sha512-Y7JLnBrXX0G7z+Zj4vRwp/Mb8fLhCc1K/LqRRQUHMmnTDb3T7xMgpM3+0ZPpedWqslWrC2OYRrOE5PQxpFnmdg==
+  dependencies:
+    "@backstage/types" "^1.1.0"
+    lodash "^4.17.21"
+
 "@backstage/core-app-api@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@backstage/core-app-api/-/core-app-api-1.8.0.tgz#b027cb069954041714be6bb0fba2802c10fa073a"
@@ -3748,6 +3756,11 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.0.2.tgz#a12cdc7c1ec7e0d99cb2e30903b9dfd97c1050c9"
   integrity sha512-wE4AAP3je00UlVNV5faIto414aOUNv30CmvNmxgImNKelPRYJsMEicM9slwkrNMyFLqTMITeXJvQvMofUk3Wxg==
+
+"@backstage/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.1.0.tgz#cf33e0c20584e329308acca2e5fa0435f04d4ea5"
+  integrity sha512-lpzZD52WHCg+i7anibmIwC3045KVOAUJ8Reoeh74+14SAQ8DTT9aUAxmH8mOFnWzDSr7XnbY5ms8Y8qWRzn2VA==
 
 "@backstage/version-bridge@^1.0.4":
   version "1.0.4"


### PR DESCRIPTION
In addition to the existing configuration, you can provide a per-cluster name configuration, which allows for different base URLs for each cluster.

```yaml
gitops:
  baseUrl: https://example.com
```

Or...

```yaml
gitops:
  cluster1:
    baseUrl: https://cluster1.example.com
  cluster2: 
    baseUrl: https://cluser2.example.com
```

This is a common pattern in Backstage plugins, https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-puppetdb/config.d.ts https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-aws/config.d.ts