### PR TITLE
Fix Updated column sorting

### DIFF
--- a/plugins/backstage-plugin-flux/src/components/helpers.tsx
+++ b/plugins/backstage-plugin-flux/src/components/helpers.tsx
@@ -536,9 +536,7 @@ export const updatedColumn = <T extends FluxObject>() => {
       }),
     ...sortAndFilterOptions(
       resource =>
-        DateTime.fromISO(automationLastUpdated(resource)).toRelative({
-          locale: 'en',
-        }) as string,
+        automationLastUpdated(resource)
     ),
     minWidth: '130px',
   } as TableColumn<T>;


### PR DESCRIPTION
This changes from using the stringified ISO timestamp to using the actual timestamp which fixes the sorting to sort in time-order rather than string-order.

Fixes #68 